### PR TITLE
Add option to manually set address

### DIFF
--- a/Olymp.Communication/NodeCommunicationClient.cs
+++ b/Olymp.Communication/NodeCommunicationClient.cs
@@ -16,6 +16,7 @@ namespace Olymp.Communication
             try
             {
                 var data = EncryptMessage(username, password, command, message);
+                // TODO: Parse ip adress better
                 client = new TcpClient(server.Split(":")[0], int.Parse(server.Split(":")[1]));
                 stream = client.GetStream();
 

--- a/Olymp.Nodes/Configuration/ConfigurationTool.cs
+++ b/Olymp.Nodes/Configuration/ConfigurationTool.cs
@@ -30,13 +30,14 @@ namespace Olymp.Nodes.Configuration
 
         public ConfigurationTool(Util.Configuration configuration)
         {
+            // TODO: Ensure appropriate settings are provided e.g. ConfigurationToolAddress, User, Password
             _configuration = configuration;
         }
 
         public void Start()
         {
             var returnedData = NodeCommunicationClient.Send(
-                _configuration.ConfigurationAddress,
+                _configuration.ConfigurationToolAddress,
                 _configuration.User,
                 _configuration.Password,
                 new SingleValueMessage {Value = CONFIG},
@@ -171,7 +172,7 @@ namespace Olymp.Nodes.Configuration
                 if (msgCommand != Command.UNKNOWN)
                 {
                     var response = NodeCommunicationClient.Send(
-                        _configuration.ConfigurationAddress,
+                        _configuration.ConfigurationToolAddress,
                         _configuration.User,
                         _configuration.Password,
                         content,

--- a/Olymp.Nodes/Node.cs
+++ b/Olymp.Nodes/Node.cs
@@ -7,19 +7,20 @@ namespace Olymp.Nodes
 {
     public abstract class Node : IService
     {
-        private readonly string _localHost = "127.0.0.1";
+        private readonly string _address;
         private readonly int _port;
         protected string _name;
 
         protected Node(Util.Configuration configuration, int port)
         {
+            _address = configuration.Address ?? "127.0.0.1";
             _port = port;
             _name = configuration.Name;
         }
 
         public void Start()
         {
-            var server = new NodeCommunicationServer(_localHost, _port, _name);
+            var server = new NodeCommunicationServer(_address, _port, _name);
             Task.Run(() => { server.Start(Handle); });
         }
 

--- a/Olymp.Util/Configuration.cs
+++ b/Olymp.Util/Configuration.cs
@@ -9,12 +9,13 @@ namespace Olymp.Util
 
     public class Configuration
     {
-        public string MasterIP;
-        public bool WebUI;
-        public Role? Role { get; set; } = null;
-        public string Name { get; set; }
-        public string ConfigurationAddress { get; set; }
-        public string User { get; set; }
-        public string Password { get; set; }
+        public string MasterIP { get; internal set; }
+        public bool WebUI { get; internal set; }
+        public Role? Role { get; internal set; } = null;
+        public string Name { get; internal set; }
+        public string ConfigurationToolAddress { get; internal set; }
+        public string Address { get; internal set; } = null;
+        public string User { get; internal set; }
+        public string Password { get; internal set; }
     }
 }

--- a/Olymp.Util/ConfigurationManager.cs
+++ b/Olymp.Util/ConfigurationManager.cs
@@ -5,7 +5,7 @@ namespace Olymp.Util
 {
     public class ConfigurationManager
     {
-        private static readonly Regex ip = new Regex("^[^\\:]*:[^\\:]*$", RegexOptions.Compiled);
+        private static readonly Regex ipRegex = new Regex("^[^\\:]*:[^\\:]*$", RegexOptions.Compiled);
 
         private static string GetValue(string[] args, ref int i)
         {
@@ -33,14 +33,20 @@ namespace Olymp.Util
                     case "-c":
                         config.Role = Role.Child;
                         config.MasterIP = GetValue(args, ref i);
-                        if (!ip.IsMatch(config.MasterIP)) throw new InvalidIpException(config.MasterIP);
+                        if (!ipRegex.IsMatch(config.MasterIP)) throw new InvalidIpException(config.MasterIP);
                         break;
                     case "--configure":
                     case "--conf":
                         config.Role = Role.ConfigurationTool;
-                        config.ConfigurationAddress = GetValue(args, ref i);
-                        if (!ip.IsMatch(config.ConfigurationAddress))
-                            throw new InvalidIpException(config.ConfigurationAddress);
+                        config.ConfigurationToolAddress = GetValue(args, ref i);
+                        if (!ipRegex.IsMatch(config.ConfigurationToolAddress))
+                            throw new InvalidIpException(config.ConfigurationToolAddress);
+                        break;
+                    case "--address":
+                    case "-a":
+                        config.Address = GetValue(args, ref i);
+                        if (!ipRegex.IsMatch(config.Address))
+                            throw new InvalidIpException(config.Address);
                         break;
                     case "--webui":
                     case "--web":


### PR DESCRIPTION
# Description

Added option to manually set the address the server will listen on.
Made the setters in the configuration internal.
Also refactored one option to ConfigurationToolAddress fro better understandability.

Fixes #21 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Test Configuration**:
* Firmware version: ----
* Hardware: my Linux laptop
* Toolchain: ----
* SDK: 2.1.503

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
